### PR TITLE
Release 1.0.6

### DIFF
--- a/Controller/Confirm/Index.php
+++ b/Controller/Confirm/Index.php
@@ -8,6 +8,7 @@ use Magento\Checkout\Model\Session;
 use Magento\Customer\Api\AccountManagementInterface;
 use Magento\Customer\Api\CustomerRepositoryInterface;
 use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\Exception\LocalizedException;
 
 class Index extends Action
 {
@@ -120,10 +121,12 @@ class Index extends Action
             $this->checkoutSessionManager->setBriqpayPaymentMethod($paymentResponse->getPurchasePaymentMethod());
 
             return $this->_redirect('briqpay/order/success');
+        } catch (LocalizedException $e) {
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
             $this->messageManager->addErrorMessage('Can not instantiate your payment request. Please try again.');
-            return $this->_redirect('checkout/cart');
         }
+        return $this->_redirect('checkout/cart');
     }
 
     /**

--- a/Controller/Update/Cart.php
+++ b/Controller/Update/Cart.php
@@ -8,6 +8,7 @@ use Briqpay\Checkout\Rest\Exception\UpdateCartException;
 use Briqpay\Checkout\Rest\Request\InitializePaymentRequestFactory;
 use Briqpay\Checkout\Rest\Service\Authentication;
 use Exception;
+use Briqpay\Checkout\Model\Checkout\CheckoutException;
 use Magento\Checkout\Controller\Action;
 use Magento\Customer\Api\AccountManagementInterface;
 use Magento\Customer\Api\CustomerRepositoryInterface;
@@ -76,12 +77,18 @@ class Cart extends Action
     public function execute()
     {
         try {
+            $this->briqpayCheckout->validate();
             $this->briqpayCheckout->updateItems(
                 $this->sessionManagement->getSessionId(),
                 $this->sessionManagement->getQuote(),
                 $this->sessionManagement->getSessionToken()
             );
 
+        } catch (CheckoutException $e) {
+            $this->getResponse()->setBody(json_encode([
+                'redirect' => '/checkout/cart'
+            ]));
+            return;
         } catch (Exception $e) {
             $this->getResponse()->setBody(json_encode([
                 'messages' => __('Can not update cart.')

--- a/Model/Checkout/BriqpayCheckout.php
+++ b/Model/Checkout/BriqpayCheckout.php
@@ -229,7 +229,7 @@ class BriqpayCheckout
     /**
      * @throws CheckoutException
      */
-    private function validate()
+    public function validate()
     {
         foreach ($this->validators as $validator) {
             $validator->validate();

--- a/Model/Quote/ValidationRules/MatchesPayment.php
+++ b/Model/Quote/ValidationRules/MatchesPayment.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Briqpay\Checkout\Model\Quote\ValidationRules;
+
+use Magento\Quote\Model\ValidationRules\QuoteValidationRuleInterface;
+use Magento\Quote\Model\Quote;
+use Magento\Framework\Validation\ValidationResultFactory;
+use Briqpay\Checkout\Rest\Adapter\ReadSession;
+use Briqpay\Checkout\Model\Checkout\CheckoutSession\SessionManagement;
+use Briqpay\Checkout\Model\Checkout\ApiBuilder\OrderLine\OrderLineCollectorsAgreggator;
+use Briqpay\Checkout\Rest\Adapter\CancelAdapter;
+use Briqpay\Checkout\Rest\Exception\AdapterException;
+
+/**
+ * Validate that quote matches Briqpay payment
+ */
+class MatchesPayment implements QuoteValidationRuleInterface
+{
+    /**
+     * @var ValidationResultFactory
+     */
+    private $resultFactory;
+
+    /**
+     * @var SessionManagement
+     */
+    private $sessionManagement;
+
+    /**
+     * @var ReadSession
+     */
+    private $readSession;
+
+    /**
+     * @var CancelAdapter
+     */
+    private $cancelAdapter;
+
+    /**
+     * @var OrderLineCollectorsAgreggator
+     */
+    private $aggregator;
+
+    /**
+     * @var Quote|null
+     */
+    private $processedQuote;
+
+    public function __construct(
+        ValidationResultFactory $resultFactory,
+        SessionManagement $sessionManagement,
+        ReadSession $readSession,
+        CancelAdapter $cancelAdapter,
+        OrderLineCollectorsAgreggator $aggregator
+    ) {
+        $this->resultFactory = $resultFactory;
+        $this->sessionManagement = $sessionManagement;
+        $this->readSession = $readSession;
+        $this->cancelAdapter = $cancelAdapter;
+        $this->aggregator = $aggregator;
+    }
+
+    public function validate(Quote $quote): array
+    {
+        $result = [$this->resultFactory->create(['errors' => []])];
+
+        if ($quote->getPayment()->getMethod() !== \Briqpay\Checkout\Model\Payment\Briqpay::CODE) {
+            return $result;
+        }
+
+        $this->processedQuote = $quote;
+
+        $valid = false;
+        try {
+            $valid = $this->compareWithPayment();
+        } catch (\Exception $e) {
+            return $this->returnError();
+        }
+
+        if (!$valid) {
+            return $this->returnError();
+        }
+
+        return $result;
+    }
+
+    /**
+     * Compares quote contets with Briqpay payment contents
+     *
+     * @return boolean
+     */
+    private function compareWithPayment(): bool
+    {
+        $quote = $this->processedQuote;
+        $getStatusResponse = $this->readSession->readSession(
+            $this->sessionManagement->getSessionId(),
+            $this->sessionManagement->getSessionToken()
+        );
+
+        $bGrandTotal = (int)$getStatusResponse->getData('amount');
+        $qGrandTotal = $this->toApiFloat(
+            $quote->getBaseGrandTotal()
+        );
+
+        if ($bGrandTotal !== $qGrandTotal) {
+            return false;
+        }
+
+        $comparisonSession = $this->aggregator->aggregateItems($quote);
+        // Sort and compare cart items
+        $bItems = $getStatusResponse->getCart();
+        $qItems = $comparisonSession->getCart();
+
+        $bItemComparison = [];
+        $qItemComparison = [];
+        foreach ($bItems->getData() as $bItem) {
+            $sku = (string)$bItem['reference'];
+            $bItemComparison[$sku] = $bItem['quantity'];
+        }
+
+        foreach ($qItems as $qItem) {
+            $sku = (string)$qItem['reference'];
+            $qItemComparison[$sku] = $qItem['quantity'];
+        }
+
+        $diff = array_diff_assoc($qItemComparison, $bItemComparison);
+        if (count($diff) > 0) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function toApiFloat($float): int
+    {
+        return (int)round($float * 100);
+    }
+
+    /**
+     * Cancel payment and return invalid status with error message
+     *
+     * @return array
+     * @throws AdapterException
+     */
+    private function returnError()
+    {
+        $this->processedQuote->getPayment()->unsAdditionalInformation();
+        $this->cancelAdapter->cancel(
+            $this->sessionManagement->getSessionToken(),
+            $this->sessionManagement->getSessionId(),
+            'Cart contents do not match payment'
+        );
+
+        $error = __(
+            'Your cart differs from the payment. '
+            . 'Please try placing the order again. '
+            . 'Avoid updating your cart in a different tab or window while completing the checkout.'
+        );
+
+        $this->sessionManagement->setSessionId(false);
+        $this->sessionManagement->setSessionToken(false);
+        return [$this->resultFactory->create(['errors' => [$error]])];
+    }
+}

--- a/Rest/Response/GetPaymentStatusResponse.php
+++ b/Rest/Response/GetPaymentStatusResponse.php
@@ -68,6 +68,11 @@ class GetPaymentStatusResponse implements ResponseInterface
         return $this->data->getData('state');
     }
 
+    public function getCart(): DataObject
+    {
+        return new DataObject($this->data->getData('cart'));
+    }
+
     /**
      * @return array|mixed|null
      */

--- a/Test/Model/Quote/ValidationRules/MatchesPaymentTest.php
+++ b/Test/Model/Quote/ValidationRules/MatchesPaymentTest.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Briqpay\Checkout\Test\Model\Quote\ValidationRules;
+
+use Briqpay\Checkout\Model\Quote\ValidationRules\MatchesPayment;
+use Briqpay\Checkout\Rest\Adapter\ReadSession;
+use Briqpay\Checkout\Model\Checkout\CheckoutSession\SessionManagement;
+use Briqpay\Checkout\Rest\Adapter\CancelAdapter;
+use Briqpay\Checkout\Rest\Response\GetPaymentStatusResponse;
+use Briqpay\Checkout\Model\Checkout\ApiBuilder\OrderLine\OrderLineCollectorsAgreggator;
+use Briqpay\Checkout\Model\Checkout\DTO\PaymentSession\CreatePaymentSession;
+use Magento\Framework\Validation\ValidationResultFactory;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\Quote\Item;
+use Magento\Quote\Model\Quote\Payment;
+use Magento\Framework\DataObject;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class MatchesPaymentTest extends TestCase
+{
+    /**
+     * @var MatchesPayment
+     */
+    private $testSubject;
+
+    /**
+     * @var ValidationResultFactory|MockObject
+     */
+    private $resultFactory;
+
+    /**
+     * @var SessionManagement|MockObject
+     */
+    private $sessionManagement;
+
+    /**
+     * @var ReadSession|MockObject
+     */
+    private $readSession;
+
+    /**
+     * @var CancelAdapter|MockObject
+     */
+    private $cancelAdapter;
+
+    /**
+     * @var OrderLineCollectorsAgreggator|MockObject
+     */
+    private $aggregator;
+
+    /**
+     * @var GetPaymentStatusResponse|MockObject
+     */
+    private $response;
+
+    /**
+     * @var DataObject
+     */
+    private $responseCart;
+
+    /**
+     * @var Quote|MockObject
+     */
+    private $quote;
+
+    /**
+     * @var Payment|MockObject
+     */
+    private $payment;
+
+    public function setUp(): void
+    {
+        $this->payment = $this->createMock(Payment::class);
+        $this->payment->method('getMethod')->willReturn('briqpay');
+
+        $this->quote = $this->getMockBuilder(Quote::class)
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->onlyMethods(['getPayment', 'getAllItems'])
+            ->addMethods(['getBaseGrandTotal'])
+            ->getMock()
+        ;
+
+        $this->quote->method('getPayment')->willReturn($this->payment);
+
+        $item1 = $this->createMock(Item::class);
+        $item1->method('getSku')->willReturn('sku1');
+        $item1->method('getQty')->willReturn(1);
+
+        $item2 = $this->createMock(Item::class);
+        $item2->method('getSku')->willReturn('sku2');
+        $item2->method('getQty')->willReturn(2);
+
+        $this->quote->method('getAllItems')->willReturn([$item1, $item2]);
+        $this->readSession = $this->createMock(ReadSession::class);
+        $this->aggregator = $this->createMock(OrderLineCollectorsAgreggator::class);
+
+        $this->resultFactory = $this->createMock(ValidationResultFactory::class);
+        $this->sessionManagement = $this->createMock(SessionManagement::class);
+        $this->cancelAdapter = $this->createMock(CancelAdapter::class);
+        $this->testSubject = new MatchesPayment(
+            $this->resultFactory,
+            $this->sessionManagement,
+            $this->readSession,
+            $this->cancelAdapter,
+            $this->aggregator
+        );
+    }
+
+    /**
+     * Test the validation when the data matches
+     *
+     * @return void
+     */
+    public function testMatchingValidate()
+    {
+        $this->response = new GetPaymentStatusResponse(new DataObject([
+            'amount' => 1000,
+            'cart' => [
+                [
+                    'reference' => 'sku1',
+                    'quantity' => 1
+                ],
+                [
+                    'reference' => 'sku2',
+                    'quantity' => 2
+                ]
+            ]
+        ]));
+        $this->readSession->method('readSession')->willReturn($this->response);
+        $paymentSession = $this->createMock(CreatePaymentSession::class);
+        $paymentSession->method('getCart')->willReturn([
+            [
+                'reference' => 'sku1',
+                'quantity' => 1
+            ],
+            [
+                'reference' => 'sku2',
+                'quantity' => 2
+            ]
+        ]);
+        $this->quote->method('getBaseGrandTotal')->willReturn(10.00);
+        $this->aggregator->method('aggregateItems')->willReturn($paymentSession);
+        $this->resultFactory->expects($this->once())->method('create')->with(['errors' => []]);
+        $this->testSubject->validate($this->quote);
+    }
+
+    /**
+     * Test the validation when the data doesn't match
+     *
+     * @return void
+     */
+    public function testNotMatchingValidate()
+    {
+        $this->response = new GetPaymentStatusResponse(new DataObject([
+            'amount' => 1000,
+            'cart' => [
+                [
+                    'reference' => 'sku1',
+                    'quantity' => 1
+                ],
+                [
+                    'reference' => 'sku2',
+                    'quantity' => 2
+                ]
+            ]
+        ]));
+        $this->readSession->method('readSession')->willReturn($this->response);
+        $paymentSession = $this->createMock(CreatePaymentSession::class);
+        $paymentSession->method('getCart')->willReturn([
+            [
+                'reference' => 'sku1',
+                'quantity' => 1
+            ],
+            [
+                'reference' => 'sku2',
+                'quantity' => 3
+            ]
+        ]);
+        $this->quote->method('getBaseGrandTotal')->willReturn(15.00);
+        $this->aggregator->method('aggregateItems')->willReturn($paymentSession);
+        $this->cancelAdapter->expects($this->atLeastOnce())->method('cancel');
+        $this->testSubject->validate($this->quote);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,5 @@
             "Briqpay\\Checkout\\": ""
         }
     },
-    "version": "1.0.5"
+    "version": "1.0.6"
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -26,6 +26,13 @@
         <plugin name="briqpay_url" type="Briqpay\Checkout\Plugin\Url" sortOrder="10" disabled="false"/>
     </type>
 
+    <type name="Magento\Quote\Model\ValidationRules\QuoteValidationComposite">
+        <arguments>
+            <argument name="validationRules" xsi:type="array">
+                <item name="matchesPaymentRule" xsi:type="object">Briqpay\Checkout\Model\Quote\ValidationRules\MatchesPayment</item>
+            </argument>
+        </arguments>
+    </type>
 
     <virtualType name="BriqpayConfig" type="\Magento\Payment\Gateway\Config\Config">
         <arguments>

--- a/i18n/sv_SE.csv
+++ b/i18n/sv_SE.csv
@@ -46,3 +46,4 @@
 "Denmark", "Danska"
 "Finland", "Finland"
 "Norway", "Norska"
+"Your cart differs from the payment. Please try placing the order again. Avoid updating your cart in a different tab or window while completing the checkout.","Din varukorg stämmer inte överens med betalningen. Vänligen försök beställa igen. Undvik att ändra varukorgen i annan flik eller annat fönster medan du beställer."


### PR DESCRIPTION
* Adds quote validation rule comparing quote contents with Briqpay payment contents, preventing diffs when order is placed
* Adds validation on cart update in checkout. Will now redirect to checkout/cart on validation error, including if cart was emptied.